### PR TITLE
fixed signing on windows

### DIFF
--- a/aws_sdk/signaturev4.nim
+++ b/aws_sdk/signaturev4.nim
@@ -24,7 +24,7 @@ proc formattedHeaderNamesStr[T](headers: T): string =
   result = join(sortedByIt(lowerSignedHeaders, it), ";")
 
 proc canonicalQueryv4(request: AwsRequest): string =
-  let signedHeadersStr = formattedHeaderNamesStr(request.headers)  
+  let signedHeadersStr = formattedHeaderNamesStr(request.headers)
   let payloadHashHex = toLower(hexify(request.payloadHash))
   let unsortedPairs = asKeyVal(toSeq(pairs(request.headers)))
   let sortedHeaderPairs = sortedByIt(unsortedPairs, it.key)
@@ -32,8 +32,8 @@ proc canonicalQueryv4(request: AwsRequest): string =
     let k = toLower(it.key)
     let v = replace(it.value, re"\s+", " ")
     "$1:$2" % [k, v]
-  let canonicalHeadersStr = join(canonicalHeaders, "\n")
-  
+  let canonicalHeadersStr = join(canonicalHeaders, "\l")
+
   let lines = [
     toUpper(request.httpMethod),
     request.uri.path,
@@ -43,14 +43,14 @@ proc canonicalQueryv4(request: AwsRequest): string =
     signedHeadersStr,
     payloadHashHex
   ]
-  result = join(lines, "\n")
+  result = join(lines, "\l")
 
 proc signableStringv4(scope: AwsCredentialScope, request: AwsRequest): string =
   let algorithmDesignation = AwsDefaultAlgorithmv4
-  
-  let timestampKey = if hasKey(request.headers, "X-Amz-Date"): "X-Amz-Date" else: "Date" 
+
+  let timestampKey = if hasKey(request.headers, "X-Amz-Date"): "X-Amz-Date" else: "Date"
   let timestamp = request.headers[timestampKey]
-  
+
   let canonicalHash = sphHash[SHA256](canonicalQueryv4(request))
   let signableLines = [
     algorithmDesignation,
@@ -58,44 +58,44 @@ proc signableStringv4(scope: AwsCredentialScope, request: AwsRequest): string =
     $scope,
     hexify(canonicalHash)
   ]
-  result = join(signableLines, "\n")
-  
+  result = join(signableLines, "\l")
+
 proc signingKeyv4(credentials: AwsCredentials, scope: AwsCredentialScope): string =
   let dateKey = "AWS4$1" % [credentials.secretKey]
   let date = format(getGMTime(scope.time), AwsDateFormatv4)
   let dateHmac = sphHmac[SHA256](dateKey, date)
   let regionHmac = sphHmac[SHA256](dateHmac, scope.region)
   let serviceHmac = sphHmac[SHA256](regionHmac, scope.service)
-  result = sphHmac[SHA256](serviceHmac, "aws4_request") 
-  
+  result = sphHmac[SHA256](serviceHmac, "aws4_request")
+
 proc signaturev4*(
-  credentials: AwsCredentials, 
+  credentials: AwsCredentials,
   scope: AwsCredentialScope,
   request: AwsRequest
 ): string =
   let signableStr = signableStringv4(scope, request)
   let key = signingKeyv4(credentials, scope)
   result = hexify(sphHmac[SHA256](key, signableStr))
-  
+
 proc authorizationHeaderv4*(
-  credentials: AwsCredentials, 
+  credentials: AwsCredentials,
   scope: AwsCredentialScope,
   request: AwsRequest
 ): string =
   let signedHeadersStr = formattedHeaderNamesStr(request.headers)
   let signature = signaturev4(credentials, scope, request)
-  
+
   result = "$1 Credential=$2/$3, SignedHeaders=$4, Signature=$5" % [
-    AwsDefaultAlgorithmv4, 
-    credentials.accessKeyId, 
-    $scope, 
-    signedHeadersStr, 
+    AwsDefaultAlgorithmv4,
+    credentials.accessKeyId,
+    $scope,
+    signedHeadersStr,
     signature
   ]
-  
+
 proc authenticationQueryParamsv4(
-  credentials: AwsCredentials, 
-  scope: AwsCredentialScope, 
+  credentials: AwsCredentials,
+  scope: AwsCredentialScope,
   request: AwsRequest,
   expiry: int
 ): StringTableRef =
@@ -109,7 +109,7 @@ proc authenticationQueryParamsv4(
 proc authenticatedUriv4*(
   request: AwsRequest,
   credentials: AwsCredentials,
-  scope: AwsCredentialScope, 
+  scope: AwsCredentialScope,
   expiry: int
 ): Uri =
   let queryP = queryParams(request.uri)
@@ -117,7 +117,7 @@ proc authenticatedUriv4*(
   let mergedParams = mergedTables(queryP, authParams)
   mergedParams["X-Amz-Signature"] = signaturev4(credentials, scope, request)
   if not isNil(credentials.token): mergedParams["X-Amz-Security-Token"] = credentials.token
-  
+
   var uri = request.uri
   setQueryParams(uri, mergedParams)
   result = uri
@@ -127,30 +127,30 @@ when defined(testing):
   # from http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
   let credentials = AwsCredentials(accessKeyId: "AKIDEXAMPLE", secretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
   let scope = AwsCredentialScope(time: fromSeconds(1440938160), region: "us-east-1", service: "iam")
-  
+
   let headers = {
-    "Host": "iam.amazonaws.com", 
+    "Host": "iam.amazonaws.com",
     "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
     "X-Amz-Date": "20150830T123600Z"
   }
-  
+
   let request = AwsRequest[StringTableRef](
-    httpMethod: "GET", 
-    uri: parseUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"), 
-    headers: newStringTable(headers), 
+    httpMethod: "GET",
+    uri: parseUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"),
+    headers: newStringTable(headers),
     payloadHash: dehexify("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
   )
-  
+
   let request2 = AwsRequest[Table[string, string]](
-    httpMethod: "GET", 
-    uri: parseUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"), 
-    headers: toTable(headers), 
+    httpMethod: "GET",
+    uri: parseUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"),
+    headers: toTable(headers),
     payloadHash: dehexify("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
   )
-  
+
   check:
     authorizationHeaderv4(credentials, scope, request2) == "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"
-  
+
   check:
     signingKeyv4(credentials, scope) == dehexify("c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9")
     signaturev4(credentials, scope, request) == "5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"
@@ -158,10 +158,10 @@ when defined(testing):
       20150830T123600Z
       20150830/us-east-1/iam/aws4_request
       f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59""")
-    
+
     authenticatedUriv4(request, credentials, scope, 60) == parseUri("https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIDEXAMPLE%2F20150830%2Fus-east-1%2Fiam%2Faws4_request&X-Amz-Date=20150830T123600Z&X-Amz-Expires=60&X-Amz-Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7&X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-date")
     authorizationHeaderv4(credentials, scope, request) == "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"
-    
+
     canonicalQueryv4(request) == deindent("""GET
       /
       Action=ListUsers&Version=2010-05-08


### PR DESCRIPTION
nim expands \n to \c\r on windows, thus the hashes of the canonical query string were quite wrong. \l is just a simple newline on all platforms,
